### PR TITLE
Add --output-directory option to ronn

### DIFF
--- a/bin/ronn
+++ b/bin/ronn
@@ -16,6 +16,7 @@
 #/   -5, --html                generate entire HTML page with layout
 #/   -f, --fragment            generate HTML fragment
 #/       --markdown            generate post-processed markdown output
+#/   -o, --output-directory=<dir>  place generated files in the specified directory
 #/
 #/ Document attributes:
 #/       --date=<date>          published date in YYYY-MM-DD format (bottom-center)
@@ -71,6 +72,7 @@ view    = false
 server  = false
 formats = nil
 options = {}
+output_directory = nil
 write_index = false
 styles  = %w[man]
 groff   = "groff -Wall -mtty-char -mandoc -Tascii"
@@ -101,6 +103,7 @@ ARGV.options do |argv|
   argv.on("-5", "--html")     { (formats ||= []) << 'html' }
   argv.on("-f", "--fragment") { (formats ||= []) << 'html_fragment' }
   argv.on("--markdown")       { (formats ||= []) << 'markdown' }
+  argv.on("-o", "--output-directory=V") { |val| output_directory = val }
 
   # html output options
   argv.on("-s", "--style=V")  { |val| styles += val.split(/[, \n]+/) }
@@ -163,7 +166,7 @@ end
 
 pid = nil
 wr = STDOUT
-documents = ARGV.map { |file| Ronn::Document.new(file, options) }
+documents = ARGV.map { |file| Ronn::Document.new(file, output_directory, options) }
 documents.each do |doc|
   # setup the man pipeline if the --man option was specified
   if view && !build

--- a/lib/ronn/document.rb
+++ b/lib/ronn/document.rb
@@ -62,8 +62,9 @@ module Ronn
     # calling the block. The document is loaded and preprocessed before
     # the intialize method returns. The attributes hash may contain values
     # for any writeable attributes defined on this class.
-    def initialize(path=nil, attributes={}, &block)
+    def initialize(path=nil, output_path=nil, attributes={}, &block)
       @path = path
+      @output_path = output_path
       @basename = path.to_s =~ /^-?$/ ? nil : File.basename(path)
       @reader = block ||
         lambda do |f|
@@ -100,7 +101,7 @@ module Ronn
     # appends it to the dirname of the source document.
     def path_for(type=nil)
       if @basename
-        File.join(File.dirname(path), basename(type))
+        File.join(File.dirname(@output_path || path), basename(type))
       else
         basename(type)
       end

--- a/man/ronn.1.ronn
+++ b/man/ronn.1.ronn
@@ -7,6 +7,7 @@ ronn(1) -- convert markdown files to manpages
 `ronn` `-m`|`--man` <file>...<br>
 `ronn` `-S`|`--server` <file>...<br>
 `ronn` `--pipe` <file><br>
+`ronn` `--output-directory` <dir> <file>...<br>
 `ronn` &lt; <file>
 
 ## DESCRIPTION
@@ -24,6 +25,9 @@ same directory as input <file>s.
 The `--server` and `--man` options change the output behavior from file
 generation to serving dynamically generated HTML manpages or viewing <file> as
 with man(1).
+
+The `--output-directory` options changes the output behavior so outputs are
+generated in the specified directory.
 
 With no <file> arguments, `ronn` acts as simple filter. Ronn source text is read
 from standard input and roff output is written to standard output. Use the
@@ -85,6 +89,9 @@ and `--html` are assumed.
   * `-f`, `--fragment`:
     Generate output in HTML format but only the document fragment, not the
     header, title, or footer.
+
+  * `-o`, `--output-directory`=<dir>:
+    Generate output in the specified directory instead of the source directory.
 
 Document attributes displayed in the header and footer areas of generated
 content are specified with these options. (These values may also be set via


### PR DESCRIPTION
Allows the user to specifiy where generated outputs should be placed.

Fixes: #4